### PR TITLE
Change site title and re-arrange front page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,8 +18,8 @@
 # You can create any custom variable you would like, and they will be accessible
 # in the templates via {{ site.myvariable }}.
 
-title: CoderDojo @ Bradfield 
-email: your-email@example.com
+title: Cambridge Science Park CoderDojo
+email: info@camcoderdojo.com
 description: >- # this means to ignore newlines until "baseurl:"
     CoderDojo is a programming club where young people can learn to code, 
     be inspired by their peers, and, most importantly, have fun! The
@@ -63,9 +63,9 @@ include:
 #   - vendor/ruby/
 
 author:
-  name	: "CoderDojo@Bradfield"
+  name	: "Cambridge Science Park CoderDojo"
   avatar: "/assets/images/bio-photo.jpg"
-  bio	: "We meet Saturdays at the Cambridge Science Park."
+  bio	: "We meet Saturdays at the Bradfield Centre at the Cambridge Science Park."
 
 # We currently list events past and present as posts
 # we may want to consider splitting them up into their own

--- a/index.md
+++ b/index.md
@@ -36,10 +36,6 @@ Everyone is welcome, regardless of coding experience. Our intro activities are s
 attendees who are coding for the very first time. Seasoned coders can come to discover new
 tools and languages or get help implementing their own projects from our volunteers.
 
-### Photos of Previous Events
-
-{% include gallery %}
-
 ### CoderDojo Events at The Bradfield Center
 
 You can view and register for our upcoming events on our [Eventbrite page](https://www.eventbrite.com/o/coderdojo-the-bradfield-center-and-central-working-27608623949). Registering is quick, easy and free. You'll need to provide your name and email address to Eventbrite to register for our events.
@@ -54,4 +50,8 @@ Our upcoming events in the near future:
 
 The Bradfield Center is located in the Cambridge Science Park.
 
-<iframe src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d9774.126849806922!2d0.1463065!3d52.2337252!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x410ce131c2898905!2sThe%20Bradfield%20Centre!5e0!3m2!1sen!2suk!4v1580168586746!5m2!1sen!2suk" width="600" height="450" frameborder="0" style="border:0;" allowfullscreen=""></iframe>
+<iframe src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d9774.126849806922!2d0.1463065!3d52.2337252!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0x410ce131c2898905!2sThe%20Bradfield%20Centre!5e0!3m2!1sen!2suk!4v1580168586746!5m2!1sen!2suk" frameborder="0" style="border:0;width:100%;height:400px" allowfullscreen=""></iframe>
+### Photos of Previous Events
+
+{% include gallery %}
+


### PR DESCRIPTION
Slightly change our site name from CoderDojo @ Bradfield to Cambridge Science Park CoderDojo since our official name on CoderDojo is Cambridge Science Park @ Bradfield. This helps us not use the @ sign in too many different contexts. Re-order info on the front page to put frequently changing items (event dates) at the top. Finally, make the google map iframe more responsive so that it looks better on mobile phone screens.