### PR TITLE
March cancellation

### DIFF
--- a/_posts/2020-03-21-virtualdojo.md
+++ b/_posts/2020-03-21-virtualdojo.md
@@ -1,0 +1,18 @@
+---
+title:  "March CoderDojo: A Virtual CoderDojo"
+date:   2020-03-14 00:12:37 +0000
+categories: event
+
+---
+
+We thought it would be best for everyone to stay healthy this month. So, instead 
+of meeting in person we thought we would suggest activities you can do at your computer 
+at home. We are still working on getting this content ready so stay tuned!
+
+## Things to look forward to
+- A cool storytelling tool that we recently learned about
+- Suggestions for things to try
+- Tips for saving and sharing your projects with other CoderDojo Ninjas
+- Ways to get in touch with a mentor if you need help
+
+As always, if there's something you're working on already you should work on that!

--- a/index.md
+++ b/index.md
@@ -24,6 +24,16 @@ gallery:
     image_path: /assets/images/gallery/thumbs/photo009-th.jpg
 ---
 
+<div style="border: 2px solid red; padding: 1em;">
+
+<h3 style="margin-top: 0;">Important Notice</h3>
+
+We are prioritizing the health and well-being of our attendees and will be <strong>cancelling our 21 March session</strong>. 
+We will provide a virtual CoderDojo experience where we will introduce new activities and present 
+ways for CoderDojo Ninjas to share their work on our <a href="/event/virtualdojo">March CoderDojo Page</a>
+
+</div>
+
 ### Have Fun and Learn to Code!
 
 [![makecode-maze](/assets/images/poster.jpg)](https://zen.coderdojo.com/dojos/gb/cambridge/science-park-cambridge-the-bradfield-centre)
@@ -42,9 +52,11 @@ You can view and register for our upcoming events on our [Eventbrite page](https
 
 Our upcoming events in the near future:
 
-- [15 February 2020](https://www.eventbrite.com/e/free-coderdojo-kids-7-17-learn-to-code-february-2020-tickets-91569838853)
-- [21 March 2020](https://www.eventbrite.com/e/free-coderdojo-kids-7-17-learn-to-code-march-2020-tickets-91570262119)
+- <del>21 March 2020</del> **Event Cancelled** Activities to do at home will be on our [March CoderDojo Page](/event/virtualdojo).
 - [18 April 2020](https://www.eventbrite.com/e/free-coderdojo-kids-7-17-learn-to-code-april-2020-tickets-91570280173)
+- [16 May 2020](https://www.eventbrite.com/e/98782261403)
+- [20 June 2020](https://www.eventbrite.com/e/98783354673)
+- [18 July 2020](https://www.eventbrite.com/e/98783469015)
 
 ### Getting to The Bradfield Center
 


### PR DESCRIPTION
Add a cancellation notice (in a red box) at the top of the page. Remove March date to eventbrite but add future ones. Also add a placeholder page (that we will later update) for next week's "virtual" event.